### PR TITLE
feat: category-based search

### DIFF
--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/book/service/BookService.java
@@ -59,7 +59,7 @@ public class BookService {
         return bookClient.getBookById(bookId);
         } catch (FeignException e) {
             throw new FeignClientServerFailConnectionException(
-                    new ErrorResponseDto(404,"404","해당 도서를 찾을 수 없습니다.", RedirectType.REDIRECT,"/books/get", null));
+                    new ErrorResponseDto(404,"404","해당 도서를 찾을 수 없습니다.", RedirectType.REDIRECT,"/books/search", null));
         }
     }
 }

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/category/client/CategoryClient.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/category/client/CategoryClient.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.twojopingfront.bookset.category.client;
+
+import com.nhnacademy.twojopingfront.bookset.category.dto.GetAllCategoriesResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@FeignClient(name = "CategoryClient", url = "${gateway.base-url}")
+public interface CategoryClient {
+    @GetMapping("/v1/bookstore/categories")
+    ResponseEntity<List<GetAllCategoriesResponse>> getAllCategories();
+}

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/category/dto/GetAllCategoriesResponse.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/category/dto/GetAllCategoriesResponse.java
@@ -1,0 +1,6 @@
+package com.nhnacademy.twojopingfront.bookset.category.dto;
+
+public record GetAllCategoriesResponse(
+        Long categoryId,
+        String name
+) {}

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/category/service/CategoryService.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/category/service/CategoryService.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.twojopingfront.bookset.category.service;
+
+import com.nhnacademy.twojopingfront.bookset.category.client.CategoryClient;
+import com.nhnacademy.twojopingfront.bookset.category.dto.GetAllCategoriesResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryClient categoryClient;
+    public List<GetAllCategoriesResponse> getAllCategories() {
+        return categoryClient.getAllCategories().getBody();
+    }
+}

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/controller/ElasticController.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/controller/ElasticController.java
@@ -1,5 +1,7 @@
 package com.nhnacademy.twojopingfront.bookset.elastic.controller;
 
+import com.nhnacademy.twojopingfront.bookset.category.dto.GetAllCategoriesResponse;
+import com.nhnacademy.twojopingfront.bookset.category.service.CategoryService;
 import com.nhnacademy.twojopingfront.bookset.elastic.dto.response.ElasticSearchResponseDto;
 import com.nhnacademy.twojopingfront.bookset.elastic.service.ElasticService;
 import lombok.RequiredArgsConstructor;
@@ -10,29 +12,40 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @Controller
 @RequiredArgsConstructor
 public class ElasticController {
 
     private final ElasticService elasticService;
+    private final CategoryService categoryService;
 
     @GetMapping("/books/search")
     public String searchBooks(
             @RequestParam(name = "keyword", required = false, defaultValue = "") String keyword,
+            @RequestParam(name = "categoryId", required = false) Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size,
             @RequestParam(name = "sort", required = false, defaultValue = "relevance") String sort,
             Model model) {
 
         // 검색 결과 가져오기
-        Page<ElasticSearchResponseDto> books = elasticService.searchBooks(keyword, PageRequest.of(page, size), sort);
+        Page<ElasticSearchResponseDto> books = elasticService.searchBooks(keyword, categoryId, PageRequest.of(page, size), sort);
+        List<GetAllCategoriesResponse> categories = categoryService.getAllCategories();
+
+        // 카테고리 순서를 역순으로 변경
+        books.getContent().forEach(ElasticSearchResponseDto::getReversedBookCategory);
 
         // 모델에 검색 결과와 페이징 정보 추가
         model.addAttribute("books", books);
         model.addAttribute("keyword", keyword);
+        model.addAttribute("categories", categories);
+        model.addAttribute("categoryId", categoryId);
         model.addAttribute("sort", sort);
         model.addAttribute("currentPath", "/books/search");
 
         return "bookset/search/search-list";
     }
 }
+

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/dto/response/ElasticSearchResponseDto.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/dto/response/ElasticSearchResponseDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.util.Collections;
 import java.util.List;
 
 @Document(indexName = "ejoping-books")
@@ -64,6 +66,13 @@ public record ElasticSearchResponseDto (
             Long id,
             @JsonProperty("name")
             String name) {
+    }
+
+    // 카테고리 역순 정렬 메소드
+    public void getReversedBookCategory() {
+        if (bookCategory != null) {
+            Collections.reverse(bookCategory);
+        }
     }
 }
 

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/repository/ElasticRepositoryCustom.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/repository/ElasticRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ElasticRepositoryCustom {
-    Page<ElasticSearchResponseDto> searchByKeyword(String keyword, Pageable pageable, String sort);
+    Page<ElasticSearchResponseDto> searchByKeyword(String keyword, Long categoryId, Pageable pageable, String sort);
 }

--- a/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/service/ElasticService.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/bookset/elastic/service/ElasticService.java
@@ -13,7 +13,7 @@ public class ElasticService {
 
     private final ElasticRepositoryCustom elasticRepository;
 
-    public Page<ElasticSearchResponseDto> searchBooks(String keyword, Pageable pageable, String sort) {
-        return elasticRepository.searchByKeyword(keyword, pageable, sort);
+    public Page<ElasticSearchResponseDto> searchBooks(String keyword, Long categoryId, Pageable pageable, String sort) {
+        return elasticRepository.searchByKeyword(keyword, categoryId, pageable, sort);
     }
 }

--- a/src/main/java/com/nhnacademy/twojopingfront/common/base/controller/IndexController.java
+++ b/src/main/java/com/nhnacademy/twojopingfront/common/base/controller/IndexController.java
@@ -1,9 +1,11 @@
 package com.nhnacademy.twojopingfront.common.base.controller;
 
-import com.nhnacademy.twojopingfront.bookset.book.dto.response.BookSimpleResponseDto;
 import com.nhnacademy.twojopingfront.bookset.book.service.BookService;
+import com.nhnacademy.twojopingfront.bookset.elastic.dto.response.ElasticSearchResponseDto;
+import com.nhnacademy.twojopingfront.bookset.elastic.service.ElasticService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -16,14 +18,23 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/")
 public class IndexController {
     private final BookService bookService;
+    private final ElasticService elasticService;
 
     @GetMapping
-    public String index(@RequestParam(defaultValue = "0") int page,
-                        @RequestParam(defaultValue = "10") int size,
+    public String index(@RequestParam(name = "categoryId", required = false) Long categoryId,
+                        @RequestParam(defaultValue = "0") int page,
+                        @RequestParam(defaultValue = "12") int size,
+                        @RequestParam(name = "sort", required = false, defaultValue = "relevance") String sort,
                         @CookieValue(name = "accessToken", defaultValue = "") String accessToken,
                         Model model) {
-        Page<BookSimpleResponseDto> books = bookService.getAllBooks(page, size);
+        Page<ElasticSearchResponseDto> books = elasticService.searchBooks("", categoryId, PageRequest.of(page, size), sort);
+
+        // 카테고리 순서를 역순으로 변경
+        books.getContent().forEach(ElasticSearchResponseDto::getReversedBookCategory);
+
         model.addAttribute("books", books);
+        model.addAttribute("categoryId", categoryId);
+        model.addAttribute("sort", sort);
         model.addAttribute("token", accessToken);
 
         return "common/index";

--- a/src/main/resources/static/css/search-style.css
+++ b/src/main/resources/static/css/search-style.css
@@ -294,3 +294,56 @@
     margin-left: 5px;
 }
 
+/* 컨테이너 스타일 */
+.content-wrapper {
+    display: flex;
+    flex-direction: row;
+}
+
+/* 카테고리 사이드바 */
+.category-sidebar {
+    width: 250px;
+    background-color: #f9f9f9;
+    padding: 20px;
+    border-right: 1px solid #ddd;
+}
+
+.category-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.category-item > a {
+    text-decoration: none;
+    color: #333;
+    font-weight: bold;
+    margin-bottom: 10px;
+    display: block;
+    padding: 5px;
+    transition: all 0.3s ease;
+}
+
+.category-item > a:hover {
+    color: #944cff;
+}
+
+.sub-category-item > a {
+    text-decoration: none;
+    color: #555;
+    margin-left: 20px;
+    display: block;
+    padding: 3px;
+    transition: all 0.3s ease;
+}
+
+.sub-category-item > a:hover {
+    color: #472178;
+}
+
+/* 메인 콘텐츠 */
+.main-content {
+    flex: 1;
+    padding: 20px;
+    overflow-x: auto;
+}

--- a/src/main/resources/templates/bookset/search/search-list.html
+++ b/src/main/resources/templates/bookset/search/search-list.html
@@ -10,115 +10,142 @@
 <body>
 
 <div class="container" layout:fragment="content">
-    <!-- 검색 입력 -->
-    <div class="search-container">
-        <form action="/books/search" method="get">
-            <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
-            <button type="submit" class="btn btn-primary">검색</button>
-        </form>
-    </div>
-
-    <!-- 정렬 버튼 -->
-    <div class="sort-buttons-section">
-        <div class="sort-buttons">
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="popularity">
-                <button type="submit" class="btn btn-outline-secondary">인기도순</button>
-            </form>
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="newest">
-                <button type="submit" class="btn btn-outline-secondary">신상품순</button>
-            </form>
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="lowest_price">
-                <button type="submit" class="btn btn-outline-secondary">최저가순</button>
-            </form>
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="highest_price">
-                <button type="submit" class="btn btn-outline-secondary">최고가순</button>
-            </form>
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="rating">
-                <button type="submit" class="btn btn-outline-secondary">평점순</button>
-            </form>
-            <form action="/books/search" method="get">
-                <input type="hidden" name="keyword" th:value="${keyword}">
-                <input type="hidden" name="sort" value="reviews">
-                <button type="submit" class="btn btn-outline-secondary">리뷰순</button>
-            </form>
+    <div class="content-wrapper">
+        <!-- 카테고리 사이드바 -->
+        <div class="category-sidebar">
+            <ul class="category-list">
+                <li th:each="category : ${categories}"
+                    th:classappend="${categoryId == category.categoryId} ? 'active-category'">
+                    <span class="category-item">
+                        <a th:href="@{/books/search(categoryId=${category.categoryId}, keyword=${keyword}, sort=${sort})}"
+                           th:text="${category.name}"></a>
+                    </span>
+                </li>
+            </ul>
         </div>
-    </div>
+        <div class="main-content">
+            <!-- 검색 입력 -->
+            <div class="search-container">
+                <form action="/books/search" method="get">
+                    <input type="hidden" name="categoryId" th:value="${categoryId}">
+                    <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
+                    <button type="submit" class="btn btn-primary">검색</button>
+                </form>
+            </div>
 
-    <!-- 도서 목록 -->
-    <div class="card-container">
-        <div class="no-results" th:if="${books.totalElements == 0}">
-            <p>검색 결과가 없습니다.</p>
-        </div>
-        <div th:each="book, iterStat : ${books.content}" class="book-card-wrapper">
-            <!-- 번호 표시 -->
-            <div class="book-index" th:text="${(books.number * books.size) + iterStat.index + 1}"></div>
+            <!-- 정렬 버튼 -->
+            <div class="sort-buttons-section">
+                <div class="sort-buttons">
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="popularity">
+                        <button type="submit" class="btn btn-outline-secondary">인기도순</button>
+                    </form>
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="newest">
+                        <button type="submit" class="btn btn-outline-secondary">신상품순</button>
+                    </form>
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="lowest_price">
+                        <button type="submit" class="btn btn-outline-secondary">최저가순</button>
+                    </form>
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="highest_price">
+                        <button type="submit" class="btn btn-outline-secondary">최고가순</button>
+                    </form>
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="rating">
+                        <button type="submit" class="btn btn-outline-secondary">평점순</button>
+                    </form>
+                    <form action="/books/search" method="get">
+                        <input type="hidden" name="categoryId" th:value="${categoryId}">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <input type="hidden" name="sort" value="reviews">
+                        <button type="submit" class="btn btn-outline-secondary">리뷰순</button>
+                    </form>
+                </div>
+            </div>
 
-            <!-- 도서 카드 -->
-            <a class="book-card" th:href="@{/books/{bookId}(bookId=${book.bookId})}">
+            <!-- 도서 목록 -->
+            <div class="card-container">
+                <div class="no-results" th:if="${books.totalElements == 0}">
+                    <p>검색 결과가 없습니다.</p>
+                </div>
+                <div th:each="book, iterStat : ${books.content}" class="book-card-wrapper">
+                    <!-- 번호 표시 -->
+                    <div class="book-index" th:text="${(books.number * books.size) + iterStat.index + 1}"></div>
 
-                <!-- 썸네일 -->
-                <img th:src="${book.thumbnail != null and book.thumbnail != '' ? book.thumbnail : '/images/default-book-image.jpg'}"
-                     alt="썸네일"
-                     class="book-thumbnail">
+                    <!-- 도서 카드 -->
+                    <a class="book-card" th:href="@{/books/{bookId}(bookId=${book.bookId})}">
 
-                <!-- 도서 정보 -->
-                <div class="book-info">
-                    <div class="book-title" th:title="${book.bookTitle}" th:text="${book.bookTitle}"></div>
+                        <!-- 썸네일 -->
+                        <img th:src="${book.thumbnail != null and book.thumbnail != '' ? book.thumbnail : '/images/default-book-image.jpg'}"
+                             alt="썸네일"
+                             class="book-thumbnail">
 
-                    <!-- 기여자, 출판사, 출판일시 -->
-                    <div class="book-cpp">
-                    <span  class="book-contributors" th:each="contributor, iterStat : ${book.bookContributor}">
+                        <!-- 도서 정보 -->
+                        <div class="book-info">
+                            <div class="book-title" th:title="${book.bookTitle}" th:text="${book.bookTitle}"></div>
+
+                            <!-- 기여자, 출판사, 출판일시 -->
+                            <div class="book-cpp">
+                    <span class="book-contributors" th:each="contributor, iterStat : ${book.bookContributor}">
                         <span th:text="'[' + ${contributor.role} + '] ' + ${contributor.name}"></span>
                         <span th:if="!${iterStat.last}" th:text="'| '"></span>
                     </span>
-                        <span class="book-separator">|</span>
-                        <span class="book-publisher" th:text="${book.bookPublisher}"></span>
-                        <span class="book-separator">|</span>
-                        <span class="book-published-at"
-                              th:text="${#strings.substring(book.bookPublishedAt, 0, 10)}"></span>
-                    </div>
+                                <span class="book-separator">|</span>
+                                <span class="book-publisher" th:text="${book.bookPublisher}"></span>
+                                <span class="book-separator">|</span>
+                                <span class="book-published-at"
+                                      th:text="${#strings.substring(book.bookPublishedAt, 0, 10)}"></span>
+                            </div>
 
-                    <!-- 카테고리 -->
-                    <div class="book-category" th:each="category : ${book.bookCategory}"
-                         th:text="${category.name}"></div>
+                            <!-- 카테고리 -->
+                            <div class="book-category">
+                        <span th:each="category, iterStat : ${book.bookCategory}">
+                            <span th:text="${category.name}"></span>
+                            <span th:if="!${iterStat.last}" th:text="' > '"></span>
+                        </span>
+                            </div>
 
-                    <!-- 정가 -->
-                    <div class="book-price">
-                        <span class="book-retail-price" th:text="'정가: ' + ${book.bookRetailPrice} + '원'"></span>
-                        <span class="discount-percentage"
-                              th:if="${book.bookRetailPrice > 0 and book.bookSellingPrice < book.bookRetailPrice}"
-                              th:text="'(' + ${T(java.lang.String).format('%.1f', ((book.bookRetailPrice - book.bookSellingPrice) * 100.0) / book.bookRetailPrice)} + '% 할인)'">
+                            <!-- 정가 -->
+                            <div class="book-price">
+                                <span class="book-retail-price" th:text="'정가: ' + ${book.bookRetailPrice} + '원'"></span>
+                                <span class="discount-percentage"
+                                      th:if="${book.bookRetailPrice > 0 and book.bookSellingPrice < book.bookRetailPrice}"
+                                      th:text="'(' + ${T(java.lang.String).format('%.1f', ((book.bookRetailPrice - book.bookSellingPrice) * 100.0) / book.bookRetailPrice)} + '% 할인)'">
                     </span>
-                    </div>
+                            </div>
 
-                    <!-- 판매가 -->
-                    <div class="book-selling-price" th:text="'판매가: ' + ${book.bookSellingPrice} + '원'"></div>
+                            <!-- 판매가 -->
+                            <div class="book-selling-price" th:text="'판매가: ' + ${book.bookSellingPrice} + '원'"></div>
 
-                    <!-- 평점, 리뷰수 -->
-                    <div class="book-rating">
+                            <!-- 평점, 리뷰수 -->
+                            <div class="book-rating">
                         <span th:text="${book.bookRatingAvg != null ? #strings.repeat('★', T(java.lang.Math).round(book.bookRatingAvg)) +
                                         #strings.repeat('☆', 5 - T(java.lang.Math).round(book.bookRatingAvg)) : '☆☆☆☆☆'}"></span>
-                        <span th:text="${book.bookRatingAvg != null ? book.bookRatingAvg : '0.0'}"></span>
-                        <span class="review-count"
-                              th:text="'(' + ${book.bookReviewCount != null ? book.bookReviewCount : '0'} + ')'"></span>
-                    </div>
+                                <span th:text="${book.bookRatingAvg != null ? book.bookRatingAvg : '0.0'}"></span>
+                                <span class="review-count"
+                                      th:text="'(' + ${book.bookReviewCount != null ? book.bookReviewCount : '0'} + ')'"></span>
+                            </div>
 
-                    <!-- 태그 -->
-                    <span class="book-tags">
+                            <!-- 태그 -->
+                            <span class="book-tags">
                         <span th:each="tag : ${book.bookTag}" th:text="' #' + ${tag.name}"></span>
                     </span>
+                        </div>
+                    </a>
                 </div>
-            </a>
+            </div>
         </div>
     </div>
 
@@ -130,7 +157,7 @@
             <li class="page-item" th:classappend="${!books.hasPrevious()} ? 'disabled'">
                 <a class="page-link"
                    th:if="${books.hasPrevious()}"
-                   th:href="@{${currentPath}(keyword=${keyword}, sort=${sort}, page=${books.number - 1}, size=${books.size})}"
+                   th:href="@{${currentPath}(categoryId=${categoryId}, keyword=${keyword}, sort=${sort}, page=${books.number - 1}, size=${books.size})}"
                    aria-label="Previous">&laquo; 이전</a>
                 <span class="page-link disabled" th:if="${!books.hasPrevious()}">&laquo; 이전</span>
             </li>
@@ -140,7 +167,7 @@
                 th:each="i : ${#numbers.sequence(0, books.totalPages - 1)}"
                 th:classappend="${i == books.number} ? 'active'">
                 <a class="page-link"
-                   th:href="@{${currentPath}(keyword=${keyword}, sort=${sort}, page=${i}, size=${books.size})}"
+                   th:href="@{${currentPath}(categoryId=${categoryId}, keyword=${keyword}, sort=${sort}, page=${i}, size=${books.size})}"
                    th:text="${i + 1}">1</a>
             </li>
 
@@ -148,7 +175,7 @@
             <li class="page-item" th:classappend="${!books.hasNext()} ? 'disabled'">
                 <a class="page-link"
                    th:if="${books.hasNext()}"
-                   th:href="@{${currentPath}(keyword=${keyword}, sort=${sort}, page=${books.number + 1}, size=${books.size})}"
+                   th:href="@{${currentPath}(categoryId=${categoryId}, keyword=${keyword}, sort=${sort}, page=${books.number + 1}, size=${books.size})}"
                    aria-label="Next">다음 &raquo;</a>
                 <span class="page-link disabled" th:if="${!books.hasNext()}">다음 &raquo;</span>
             </li>

--- a/src/main/resources/templates/common/index.html
+++ b/src/main/resources/templates/common/index.html
@@ -1,111 +1,69 @@
-<!doctype html>
-<html lang="ko" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout/mainpage-layout}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Two-Joping</title>
-    <link rel="stylesheet" th:href="@{/css/index-style.css}">
-
-</head>
-<body>
-<div class="main-page-container-1">
-
-<div layout:fragment="content">
-    <!-- 메인 이미지 레이아웃 -->
-    <div class="image-main-container">
-        <div class="main-image-1">
-            <div class="slide-container-1">
-                <img src="/images/index-example1.jpg" alt="Main Image 1" class="responsive-image">
-                <img src="/images/index-example2.jpg" alt="Main Image 2" class="responsive-image">
-                <img src="/images/index-example3.jpg" alt="Main Image 3" class="responsive-image">
-            </div>
-        </div>
-        <div class="main-image-2">
-            <div class="slide-container-2">
-                <img src="/images/another-example1.jpg" alt="Secondary Image 1" class="responsive-image">
-                <img src="/images/another-example2.jpg" alt="Secondary Image 2" class="responsive-image">
-                <img src="/images/another-example3.jpg" alt="Secondary Image 3" class="responsive-image">
-            </div>
-        </div>
-    </div>
-
-
-    <div class="card-container">
-        <!-- books.content가 비어있지 않을 때만 실제 데이터 반복 출력 -->
-        <div th:each="book : ${books?.content}">
-            <a th:href="@{/books/{bookId}(bookId=${book.bookId})}" class="book-card-link">
-
+<div class="card-container">
+    <!-- books.content가 비어있지 않을 때만 실제 데이터 반복 출력 -->
+    <div th:each="book : ${books?.content}">
+        <a th:href="@{/books/{bookId}(bookId=${book.bookId})}" class="book-card-link">
             <div class="book-card">
                 <!-- 책 썸네일 -->
                 <img th:src="${(book.thumbnail != null && book.thumbnail != '') ? book.thumbnail : '/images/default-book-image.jpg'}"
                      alt="썸네일" class="book-image">
 
                 <!-- 책 제목 -->
-                <div class="book-title" th:text="${book.title != null ? book.title : '제목 없음'}">책 제목</div>
+                <div class="book-title" th:text="${book.bookTitle != null ? book.bookTitle : '제목 없음'}">책 제목</div>
 
                 <div class="book-info">
                     <!-- 저자 목록 -->
                     <div class="book-author">
-                        <span th:if="${!#lists.isEmpty(book.contributorList)}">
-                            <span th:text="${book.contributorList[0].contributorName} + ' 저'"></span>
+                        <span th:if="${!#lists.isEmpty(book.bookContributor)}"
+                              th:each="contributor, iterStat : ${book.bookContributor}">
+                            <span th:text="${contributor.name} + ' 저'"></span>
+                            <span th:if="${!iterStat.last}">, </span>
                         </span>
-                        <span th:if="${#lists.isEmpty(book.contributorList)}">저자 정보 없음</span>
+                        <span th:if="${#lists.isEmpty(book.bookContributor)}">저자 정보 없음</span>
                         <span class="separator">|</span>
                         <!-- 출판사 이름 -->
-                        <span th:text="${book.publisherName != null ? book.publisherName : ' '}"></span>
+                        <span th:text="${book.bookPublisher != null ? book.bookPublisher : ' '}"></span>
                     </div>
 
                     <!-- 카테고리 목록 -->
                     <div class="book-category">
-                        <span th:if="${!#lists.isEmpty(book.categoryList)}"
-                              th:each="category, catStat : ${book.categoryList}">
-                            <span th:text="${category}"></span>
-                            <span th:if="${!catStat.last}">, </span>
+                        <span th:if="${!#lists.isEmpty(book.bookCategory)}"
+                              th:each="category, catStat : ${book.bookCategory}">
+                            <span th:text="${category.name}"></span>
+                            <span th:if="${!catStat.last}">> </span>
                         </span>
-                        <span th:if="${#lists.isEmpty(book.categoryList)}">카테고리 없음</span>
+                        <span th:if="${#lists.isEmpty(book.bookCategory)}">카테고리 없음</span>
                     </div>
                 </div>
 
                 <!-- 판매 가격 -->
-                <div class="book-price" th:text="${book.sellingPrice != null ? '₩ ' + book.sellingPrice : '가격 정보 없음'}">₩
-                    0
+                <div class="book-price"
+                     th:text="${book.bookSellingPrice != null ? '₩ ' + book.bookSellingPrice : '가격 정보 없음'}">₩ 0
                 </div>
             </div>
-            </a>
-        </div>
+        </a>
+    </div>
 
-        <!-- 마지막 줄이 4의 배수가 되도록 가짜 카드 추가 -->
-        <div th:if="${books?.content?.size() % 4 != 0}"
-             th:each="i : ${#numbers.sequence(1, 4 - (books.content.size() % 4))}">
-            <div class="spacer-card"></div>
-        </div>
+    <!-- 마지막 줄이 4의 배수가 되도록 가짜 카드 추가 -->
+    <div th:if="${books?.content?.size() % 4 != 0}"
+         th:each="i : ${#numbers.sequence(1, 4 - (books.content.size() % 4))}">
+        <div class="spacer-card"></div>
+    </div>
 
-        <!-- books가 null이거나 books.content가 비어있는 경우 예시 카드 10개 출력 -->
-        <div th:if="${books == null || #lists.isEmpty(books.content)}" th:each="i : ${#numbers.sequence(1, 10)}">
-            <div class="book-card">
-                <img src="/images/default-book-image.jpg" alt="예시 썸네일" class="book-image">
-                <div class="book-title">예시 제목</div>
-                <div class="book-info">
-                    <div class="book-author">예시 지은이 / 예시 출판사</div>
-                    <div class="book-category">예시 카테고리</div>
-                </div>
-                <div class="book-price">₩ 0</div>
+    <!-- books가 null이거나 books.content가 비어있는 경우 예시 카드 12개 출력 -->
+    <div th:if="${books == null || #lists.isEmpty(books.content)}" th:each="i : ${#numbers.sequence(1, 12)}">
+        <div class="book-card">
+            <img src="/images/default-book-image.jpg" alt="예시 썸네일" class="book-image">
+            <div class="book-title">예시 제목</div>
+            <div class="book-info">
+                <div class="book-author">예시 지은이 / 예시 출판사</div>
+                <div class="book-category">예시 카테고리</div>
             </div>
-        </div>
-
-        <!-- 예시 카드 10개가 4의 배수가 되도록 가짜 카드 추가 -->
-        <div th:if="${10 % 4 != 0}" th:each="i : ${#numbers.sequence(1, 4 - (10 % 4))}">
-            <div class="spacer-card"></div>
+            <div class="book-price">₩ 0</div>
         </div>
     </div>
 
-
-
-
+    <!-- 예시 카드 12개가 4의 배수가 되도록 가짜 카드 추가 -->
+    <div th:if="${12 % 4 != 0}" th:each="i : ${#numbers.sequence(1, 4 - (12 % 4))}">
+        <div class="spacer-card"></div>
+    </div>
 </div>
-
-
-</div>
-</body>
-</html>

--- a/src/main/resources/templates/layout/mainpage-layout.html
+++ b/src/main/resources/templates/layout/mainpage-layout.html
@@ -103,8 +103,8 @@
 <div class="sub-navbar">
   <div class="sub-navbar-container">
     <a href="/books/search?keyword=&sort=popularity" class="sub-nav-link">인기도서</a>
-    <a href="#" class="sub-nav-link">국내도서</a>
-    <a href="#" class="sub-nav-link">외국도서</a>
+    <a href="/books/search?categoryId=1&keyword=&sort=relevance" class="sub-nav-link">국내도서</a>
+    <a href="/books/search?categoryId=2&keyword=&sort=relevance" class="sub-nav-link">외국도서</a>
   </div>
 </div>
 


### PR DESCRIPTION
- 카테고리 전체 조회 front
- 카테고리별 도서 목록 조회
    - back 서버 api 사용 불가 (최하위 카테고리에 해당하는 도서만 조회)
    -  logstash MySQL 쿼리문 수정 -> 재귀 쿼리로 한 도서가 가지는 모든 카테고리 조회
- 카테고리 기반 검색 구현
    - book_category.id 필드가 특정 값(예: 1)과 정확히 일치하는 도서 목록 조회 
    - 검색, 정렬 가능
    - https://github.com/nhnacademy-be7-2joping/2joping-front/pull/58 이전 PR 참조